### PR TITLE
Add a path on the workflow requirement

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     types:
       - closed
+    paths:
+      - 'src/**'   
 
 jobs:
   docker_build:


### PR DESCRIPTION
# Description

This PR does:

- Add a `path` to the build and publish action so it does not run every time (unless action code is changed)